### PR TITLE
Support SAML SSO with omniauth-saml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trestle-omniauth (0.4.4)
+    trestle-omniauth (0.5.1)
       omniauth (~> 2.0)
       rails (>= 5.0.0)
       trestle (~> 0.9)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is a fork of the trestle-omniauth repository, so we can:
 
 1. Update the Rails version, so we aren't locked to an older version in our backend app
 2. Make some minor changes to the UI (e.g. the Login button)
+3. Support SAML SSO with omniauth-saml
 
 This gem is fetched into the backend repo via our private RubyGems repository
 hosted by GitHub. To update the gem version:
@@ -11,7 +12,7 @@ hosted by GitHub. To update the gem version:
 * Follow [these instructions](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry)
   to create a personal access token with write capabilities and configure
   `bundler` to use it.
-* Run `gem build trestle-omniauth.gemspec`
+* Run `gem build`
 * Upload it: `gem push --key github --host https://rubygems.pkg.github.com/atob-developers trestle-omniauth-VERSION.gem` (replacing VERSION with the new version number, e.g. `0.5.0`)
 
 # Trestle::Omniauth

--- a/app/controllers/trestle/omniauth/sessions_controller.rb
+++ b/app/controllers/trestle/omniauth/sessions_controller.rb
@@ -1,14 +1,23 @@
 class Trestle::Omniauth::SessionsController < Trestle::ApplicationController
-  layout "trestle/omniauth"
+  layout 'trestle/omniauth'
 
   skip_before_action :require_authenticated_user
+
+  # Disable CSRF the session creation endpoint to support SAML.
+  #
+  # The SAML IdP (e.g. Okta) performs a POST back to this endpoint to create
+  # the session. This request obvious does not originate from our web frontend;
+  # it's more like an API request where CSRF does not make sense.
+  # This is a widely documented issue with SAML and omniauth, and this is the
+  # recommended mitigation.
+  skip_before_action :verify_authenticity_token, only: :create
 
   def new
     @providers = Trestle.config.omniauth.providers.keys
   end
 
   def create
-    login!(request.env["omniauth.auth"])
+    login!(request.env['omniauth.auth'])
     redirect_to previous_location || instance_exec(&Trestle.config.omniauth.redirect_on_login)
   end
 

--- a/lib/trestle/omniauth/controller_methods.rb
+++ b/lib/trestle/omniauth/controller_methods.rb
@@ -16,7 +16,13 @@ module Trestle
       end
 
       def login!(auth_hash)
-        session[:trestle_user] = request.env['omniauth.auth'].slice(*%w[provider uid info extra]).as_json
+        trimmed_auth = auth_hash.slice(*%w[provider uid info extra])
+
+        # Remove this complex type from omniauth-saml to prevent an infinite
+        # loop when we call as_json before storing it in the session cookie.
+        trimmed_auth['extra'].delete('response_object')
+
+        session[:trestle_user] = trimmed_auth.to_h.as_json
         @current_user = auth_hash
       end
 

--- a/lib/trestle/omniauth/version.rb
+++ b/lib/trestle/omniauth/version.rb
@@ -1,5 +1,5 @@
 module Trestle
   module Omniauth
-    VERSION = '0.4.4'
+    VERSION = '0.5.1'
   end
 end


### PR DESCRIPTION
This is a batch of updates to make authenticating when SAML SSO, using
the omniauth-saml gem, work correctly. Two main changes:

* Do not include "extra" info in session to avoid infinite as_json loop
* Disable CSRF protection for "create session" endpoint, which is more
  like an API endpoint in a SAML auth flow

**Extra info**

The omniauth-saml provider includes a complex object in the
`["extra"]["response_object"]` key that can't be serialized as JSON. If
you try, it triggers an infinite loop.

This is definitely tight coupling between gems, but...oh well. This
library is small enough that I'm considering just re-implementing it
in our backend. It's more of a hassle to manage a separate package and
try to pretend we aren't modifying it to fit our specific use case.

**Disabling CSRF**

See the comment in the code for a justification of this change, which
might otherwise look like an obvious security vulnerability.

**Test Plan**

Tested in conjunction with https://github.com/AtoB-Developers/backend/pull/2739